### PR TITLE
update >=18 eligibility criteria

### DIFF
--- a/analysis/process_extract.R
+++ b/analysis/process_extract.R
@@ -106,7 +106,8 @@ if (any(unlist(check_groups) > 0)) {
 data_processed <- data_processed %>%
   mutate(
     # create variables for applying the eligibility criteria
-    aged_over_18 = age_2 >=18,
+    aged_over_18_grp_12 = (age_2 >= 18) & (jcvi_group %in% "12"),
+    aged_over_18_grps_04b_06 = (age_1 >= 18) & (jcvi_group %in% c("04b", "6")),
     alive_on_elig_date = is.na(death_date) | elig_date <= death_date,
     aged_under_120 = age_2 < 120,
     no_vax_before_start = is.na(covid_vax_disease_1_date) | as.Date(study_parameters$start_date) <= covid_vax_disease_1_date,
@@ -117,8 +118,8 @@ data_processed <- data_processed %>%
     # apply the eligibility criteria
     c0_descr = "All patients in OpenSAFELY-TPP",
     c0 = TRUE,
-    c1_descr = glue("   aged 18 years or over on {study_parameters$ref_age_2}"),
-    c1 = c0 & aged_over_18,
+    c1_descr = glue("   aged 18 years or over by {study_parameters$ref_age_2}"),
+    c1 = c0 & (aged_over_18_grp_12 | aged_over_18_grps_04b_06),
     c2_descr = "   alive at start of eligibility date",
     c2 = c1 & alive_on_elig_date,
     c3_descr = "   registered with one TPP general practice between 2020-01-01 and start of eligibility date",


### PR DESCRIPTION
I've updated the eligibility criteria for all individuals being >= 18. 

Previously this was applied by requiring `age_2 >= 18`. This was working fine for individuals in JCVI group 12 (aged 18-39) as eligibility for this group was determined by `age_2`. However, there were some people in JCVI groups 4b and 6 (at-risk or clinically vulnerable and age_1 >= 16) who had age_1 = 17 and age_2 = 18.

The updated code now requires individuals to be aged >= 18 on the date used to determine their JCVI group.

Notes:

- [reference dates for `age_1` and `age_2`](https://github.com/opensafely/covid19-vaccine-uptake-ethnicity-imd/blob/3171960e8e64f2121d892704a2d81c57d70762ab/analysis/design.R#L22C14-L23)
- [see these lines](https://github.com/opensafely/covid19-vaccine-uptake-ethnicity-imd/blob/3171960e8e64f2121d892704a2d81c57d70762ab/analysis/process_extract.R#L53-L56) for rationale for defining age on two dates